### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 ### Step 1. Download with composer
 
 ```bash
-composer require irozgar/gulp-dev-versions-bundle
+composer require irozgar/gulp-rev-versions-bundle
 ```
 
 ### Step 2. Add the bundle to AppKernel


### PR DESCRIPTION
Because of an error in the installation instructions the package installed is an older version a typo in several places.

fix issue #9
