### PR TITLE
Fixed service name

### DIFF
--- a/DependencyInjection/Compiler/SetVersionStrategyCompiler.php
+++ b/DependencyInjection/Compiler/SetVersionStrategyCompiler.php
@@ -30,7 +30,7 @@ class SetVersionStrategyCompiler implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
-        if (!$container->has('irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy')) {
+        if (!$container->has('irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy')) {
             return;
         }
 
@@ -97,7 +97,7 @@ class SetVersionStrategyCompiler implements CompilerPassInterface
 
         $defaultPackage->replaceArgument(
             $index,
-            new Reference('irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy')
+            new Reference('irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy')
         );
     }
 
@@ -112,7 +112,7 @@ class SetVersionStrategyCompiler implements CompilerPassInterface
             }
 
             $definition = $container->getDefinition((string) $package);
-            $definition->replaceArgument(1, new Reference('irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy'));
+            $definition->replaceArgument(1, new Reference('irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy'));
         }
     }
 

--- a/Tests/DependencyInjection/Compiler/SetVersionStrategyCompilerTest.php
+++ b/Tests/DependencyInjection/Compiler/SetVersionStrategyCompilerTest.php
@@ -29,13 +29,13 @@ class SetVersionStrategyCompilerTest extends PHPUnit_Framework_TestCase
 
         $container->setParameter('gulp_rev_replace_strategy', true);
         $container->setParameter('irozgar_gulp_rev.packages', array('mycdn'));
-        $container->register('irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy', $strategy);
+        $container->register('irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy', $strategy);
 
         $compiler = new SetVersionStrategyCompiler();
         $compiler->process($container);
 
         $this->assertEquals(
-            'irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy',
+            'irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy',
             (string) $package->getArgument(1)
         );
     }
@@ -52,7 +52,7 @@ class SetVersionStrategyCompilerTest extends PHPUnit_Framework_TestCase
 
         $container->setParameter('gulp_rev_replace_strategy', false);
         $container->setParameter('irozgar_gulp_rev.packages', array('mycdn'));
-        $container->register('irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy', $strategy);
+        $container->register('irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy', $strategy);
 
         $compiler = new SetVersionStrategyCompiler();
         $compiler->process($container);
@@ -84,17 +84,17 @@ class SetVersionStrategyCompilerTest extends PHPUnit_Framework_TestCase
 
         $container->setParameter('gulp_rev_replace_strategy', true);
         $container->setParameter('irozgar_gulp_rev.packages', array('mycdn', 'another'));
-        $container->register('irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy', $strategy);
+        $container->register('irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy', $strategy);
 
         $compiler = new SetVersionStrategyCompiler();
         $compiler->process($container);
 
         $this->assertEquals(
-            'irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy',
+            'irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy',
             (string) $namedPackageDefinition['mycdn']->getArgument(1)
         );
         $this->assertEquals(
-            'irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy',
+            'irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy',
             (string) $namedPackageDefinition['another']->getArgument(1)
         );
     }
@@ -120,7 +120,7 @@ class SetVersionStrategyCompilerTest extends PHPUnit_Framework_TestCase
 
         $container->setParameter('gulp_rev_replace_strategy', false);
         $container->setParameter('irozgar_gulp_rev.packages', array('mycdn'));
-        $container->register('irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy', $strategy);
+        $container->register('irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy', $strategy);
 
         $compiler = new SetVersionStrategyCompiler();
         $compiler->process($container);
@@ -130,7 +130,7 @@ class SetVersionStrategyCompilerTest extends PHPUnit_Framework_TestCase
             (string) $defaultPackageDefinition->getArgument(1)
         );
         $this->assertEquals(
-            'irozgar_gulp_dev_versions.asset.gulp_rev_version_strategy',
+            'irozgar_gulp_rev_versions.asset.gulp_rev_version_strategy',
             (string) $namedPackageDefinition['mycdn']->getArgument(1)
         );
         $this->assertEquals(


### PR DESCRIPTION
Commit 6c41fb252508c30fe044976f645f5bc68c862c40 didn't fix all typos in service name.