### PR TITLE
Update README.md configuration instructions for symfony > 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ irozgar_gulp_rev_versions:
 because twig 2.0 introduced some changes that broke compatibility with that version of 
 Symfony after its support finished ([link](https://github.com/symfony/symfony/issues/20284)).
 
-#### Symfony version = 3.1 
+#### Symfony version >= 3.1 
 
 This symfony version introduced a new option to configure the version strategy.
 


### PR DESCRIPTION
Until now configuration in the README is divided in two sections: one for Symfony versions < 3.1,
and another for Symfony versions = 3.1. With this commit it will change the = 3.1 section to include
later versions